### PR TITLE
fix: react component dist not found in online package

### DIFF
--- a/ui/react/package.json
+++ b/ui/react/package.json
@@ -56,5 +56,8 @@
       "types": "./dist/index.d.ts"
     },
     "./dist/style.css": "./dist/style.css"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I found that the npm package `@documate/react` does not have `dist` directory so we cannot import the component.